### PR TITLE
feat: periodic mapping + hanning window mapping over vis input

### DIFF
--- a/src/test/newViz.ts
+++ b/src/test/newViz.ts
@@ -6,16 +6,17 @@ const audio = document.getElementById('audio') as HTMLAudioElement;
 
 // Waviz Instance
 const viz = new Waviz(canvas, audio);
-512512512;
 //Test on play
 audio.addEventListener('play', async () => {
   viz.visualizer.render([
     {
       domain: ['time'],
-      coord: ['rect'],
+      coord: ['polar'],
       viz: ['line'],
       color: ['linearGradient'],
-      style: [20],
+      style: [],
+      periodic: true,
+      window: 'hanning'
     },
   ]);
 });

--- a/src/utils/mathUtils.ts
+++ b/src/utils/mathUtils.ts
@@ -10,3 +10,44 @@ export function mapRange(value, inMin, inMax, outMin, outMax) {
 export function mapArray(array, inMin, inMax, outMin, outMax) {
   return array.map((e) => mapRange(e, inMin, inMax, outMin, outMax));
 }
+
+//* Math that solves seaming issue in polar
+
+export function polarInter(input: number[], blendCount: number): number[] { // polar interpolation function. This function interpolates to close the gap between last and first # in data array
+  const output = input.slice();
+  const length = output.length;
+
+  for (let i = 0; i < blendCount; i++) {
+    const t = i / blendCount;
+    output[length - blendCount + 1] = output[length - blendCount + i] * (1 - t) + output[i] * t;
+  }
+
+  return output;
+}
+
+export function makePeriodic(input: number[]): number[] { // Linear periodic extension (this will help with closing the seam between first and last value in polar vis)
+  const output = input.slice();
+  const length = output.length;
+  const diff = output[length - 1] - output[0];
+
+  for (let i = 0; i < length; i++) {
+    output[i] -= (diff * i) / (length - 1);  // output[0] === output[len-1]
+  }
+ 
+  return output;
+}
+
+//* Window Functions 
+export function hanWindow(input: number[]): number[] { // Hann window (used to reduce spectral leakage through a bell-shaper curve tapering)
+  const N = input.length;
+  return input.map((v, n) => v * (0.5 - 0.5 * Math.cos((2 * Math.PI * n) / (N - 1))));
+}
+
+export function hammingWindow(input: number[]): number[] { // Hamming window (similar to hanning but with slightly modified weighting for side lobes. Useful for higher frequency resolution)
+  const N = input.length;
+  return input.map((v, n) => v * (0.54 - 0.46 * Math.cos((2 * Math.PI * n) / (N - 1))));
+}
+
+export function exponentialWindow(input: number[], a: number = 0.01): number[] { // Exponential Window (used in modal impact testing+ where emphaisis on beginning of signal is important. Good for analyzing transient signals)
+  return input.map((v, n) => v * Math.exp(-a * n));
+}

--- a/src/visualizers/Visualizer.ts
+++ b/src/visualizers/Visualizer.ts
@@ -1,5 +1,7 @@
 import AudioAnalyzer from '../analysers/analyzer';
 import { mapArray } from '../utils/mathUtils';
+import { hanWindow } from '../utils/mathUtils';
+import { makePeriodic } from '../utils/mathUtils';
 
 // Interfaces and custom types
 interface IParticle {
@@ -14,10 +16,12 @@ interface IParticle {
 
 interface IOptions {
   domain?: [string?, number?, number?];
-  coord?: [number?, number?];
+  coord?: [string?, number?, number?];
   viz?: [string?, number[] | number?, number?, number?, number?, number?];
   color?: [string | string[], string?, string | number, number?];
   style?: [number?, string?, string?];
+  periodic?: boolean;
+  window?: string;
 }
 
 // Visualizer class
@@ -407,13 +411,25 @@ class Visualizer {
         break;
     }
 
+    if (options.window && options.window.toLowerCase() === 'hanning') { //! Sample Windowing Code. Can remove if determined unecessary or want to stretch it (using switch)
+      inputData = hanWindow(inputData)
+    }
+
+    // Periodic Checker //! This will allow smoothing at the end if needed by applying linear tilt
+    if (options.periodic) { 
+      inputData = makePeriodic(inputData);
+    }
+
     // Coordinates switch
     switch (options.coord[0]) {
       case 'rect':
         data = this.dataToRect(inputData);
         break;
       case 'polar':
-        data = this.dataToPolar(inputData, options.coord[1]);
+        data = this.dataToPolar(
+          inputData, 
+          options.coord[1], // radius modifier
+        );
         break;
       default:
         data = this.dataToRect(inputData);


### PR DESCRIPTION
Added periodic mapping to fix problem where Polar mapping of Time Domain Data would have endpoints that were 'desynced'. Periodic mapping solves this by linearly tilting the data array. Made as an optional argument on our visualizer class. 

Added window mapping (sample) in visualizer with support for only hanning windows at the moment. 

Added several functions to math utils to calculate periodic mapping and hanning/hamming/exponential mapping. Only periodic and han window is currently connected. 